### PR TITLE
Make it possible to process choice nodes with type safety

### DIFF
--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice2Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice2Node.kt
@@ -5,18 +5,19 @@ import com.copperleaf.kudzu.node.NodeContext
 import com.copperleaf.kudzu.node.NonTerminalNode
 
 sealed class Choice2Node<T1 : Node, T2 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice2Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice2Node<T1, T2>(node, context)
     class Option2<T1 : Node, T2 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice2Node<T1, T2>(node, context)
 }

--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice3Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice3Node.kt
@@ -5,22 +5,23 @@ import com.copperleaf.kudzu.node.NodeContext
 import com.copperleaf.kudzu.node.NonTerminalNode
 
 sealed class Choice3Node<T1 : Node, T2 : Node, T3 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice3Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node, T3 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice3Node<T1, T2, T3>(node, context)
     class Option2<T1 : Node, T2 : Node, T3 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice3Node<T1, T2, T3>(node, context)
     class Option3<T1 : Node, T2 : Node, T3 : Node>(
-        node: T3,
+        override val node: T3,
         context: NodeContext
     ) : Choice3Node<T1, T2, T3>(node, context)
 }

--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice4Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice4Node.kt
@@ -5,26 +5,27 @@ import com.copperleaf.kudzu.node.NodeContext
 import com.copperleaf.kudzu.node.NonTerminalNode
 
 sealed class Choice4Node<T1 : Node, T2 : Node, T3 : Node, T4 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice4Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node, T3 : Node, T4 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice4Node<T1, T2, T3, T4>(node, context)
     class Option2<T1 : Node, T2 : Node, T3 : Node, T4 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice4Node<T1, T2, T3, T4>(node, context)
     class Option3<T1 : Node, T2 : Node, T3 : Node, T4 : Node>(
-        node: T3,
+        override val node: T3,
         context: NodeContext
     ) : Choice4Node<T1, T2, T3, T4>(node, context)
     class Option4<T1 : Node, T2 : Node, T3 : Node, T4 : Node>(
-        node: T4,
+        override val node: T4,
         context: NodeContext
     ) : Choice4Node<T1, T2, T3, T4>(node, context)
 }

--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice5Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice5Node.kt
@@ -5,30 +5,31 @@ import com.copperleaf.kudzu.node.NodeContext
 import com.copperleaf.kudzu.node.NonTerminalNode
 
 sealed class Choice5Node<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice5Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice5Node<T1, T2, T3, T4, T5>(node, context)
     class Option2<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice5Node<T1, T2, T3, T4, T5>(node, context)
     class Option3<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node>(
-        node: T3,
+        override val node: T3,
         context: NodeContext
     ) : Choice5Node<T1, T2, T3, T4, T5>(node, context)
     class Option4<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node>(
-        node: T4,
+        override val node: T4,
         context: NodeContext
     ) : Choice5Node<T1, T2, T3, T4, T5>(node, context)
     class Option5<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node>(
-        node: T5,
+        override val node: T5,
         context: NodeContext
     ) : Choice5Node<T1, T2, T3, T4, T5>(node, context)
 }

--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice6Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice6Node.kt
@@ -5,34 +5,35 @@ import com.copperleaf.kudzu.node.NodeContext
 import com.copperleaf.kudzu.node.NonTerminalNode
 
 sealed class Choice6Node<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice6Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice6Node<T1, T2, T3, T4, T5, T6>(node, context)
     class Option2<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice6Node<T1, T2, T3, T4, T5, T6>(node, context)
     class Option3<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node>(
-        node: T3,
+        override val node: T3,
         context: NodeContext
     ) : Choice6Node<T1, T2, T3, T4, T5, T6>(node, context)
     class Option4<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node>(
-        node: T4,
+        override val node: T4,
         context: NodeContext
     ) : Choice6Node<T1, T2, T3, T4, T5, T6>(node, context)
     class Option5<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node>(
-        node: T5,
+        override val node: T5,
         context: NodeContext
     ) : Choice6Node<T1, T2, T3, T4, T5, T6>(node, context)
     class Option6<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node>(
-        node: T6,
+        override val node: T6,
         context: NodeContext
     ) : Choice6Node<T1, T2, T3, T4, T5, T6>(node, context)
 }

--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice7Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice7Node.kt
@@ -5,38 +5,39 @@ import com.copperleaf.kudzu.node.NodeContext
 import com.copperleaf.kudzu.node.NonTerminalNode
 
 sealed class Choice7Node<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice7Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice7Node<T1, T2, T3, T4, T5, T6, T7>(node, context)
     class Option2<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice7Node<T1, T2, T3, T4, T5, T6, T7>(node, context)
     class Option3<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-        node: T3,
+        override val node: T3,
         context: NodeContext
     ) : Choice7Node<T1, T2, T3, T4, T5, T6, T7>(node, context)
     class Option4<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-        node: T4,
+        override val node: T4,
         context: NodeContext
     ) : Choice7Node<T1, T2, T3, T4, T5, T6, T7>(node, context)
     class Option5<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-        node: T5,
+        override val node: T5,
         context: NodeContext
     ) : Choice7Node<T1, T2, T3, T4, T5, T6, T7>(node, context)
     class Option6<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-        node: T6,
+        override val node: T6,
         context: NodeContext
     ) : Choice7Node<T1, T2, T3, T4, T5, T6, T7>(node, context)
     class Option7<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node>(
-        node: T7,
+        override val node: T7,
         context: NodeContext
     ) : Choice7Node<T1, T2, T3, T4, T5, T6, T7>(node, context)
 }

--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice8Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice8Node.kt
@@ -5,42 +5,43 @@ import com.copperleaf.kudzu.node.NodeContext
 import com.copperleaf.kudzu.node.NonTerminalNode
 
 sealed class Choice8Node<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice8Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
     class Option2<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
     class Option3<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T3,
+        override val node: T3,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
     class Option4<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T4,
+        override val node: T4,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
     class Option5<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T5,
+        override val node: T5,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
     class Option6<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T6,
+        override val node: T6,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
     class Option7<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T7,
+        override val node: T7,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
     class Option8<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node>(
-        node: T8,
+        override val node: T8,
         context: NodeContext
     ) : Choice8Node<T1, T2, T3, T4, T5, T6, T7, T8>(node, context)
 }

--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice9Node.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/choice/Choice9Node.kt
@@ -6,46 +6,47 @@ import com.copperleaf.kudzu.node.NonTerminalNode
 
 /* ktlint-disable max-line-length */
 sealed class Choice9Node<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-    val node: Node,
+    node: Node,
     context: NodeContext
 ) : NonTerminalNode(context) {
+    abstract val node: Node
     override val children: List<Node> = listOf(node)
     override val astNodeName: String get() = "Choice9Node.${this::class.simpleName!!}"
 
     class Option1<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T1,
+        override val node: T1,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option2<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T2,
+        override val node: T2,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option3<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T3,
+        override val node: T3,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option4<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T4,
+        override val node: T4,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option5<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T5,
+        override val node: T5,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option6<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T6,
+        override val node: T6,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option7<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T7,
+        override val node: T7,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option8<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T8,
+        override val node: T8,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
     class Option9<T1 : Node, T2 : Node, T3 : Node, T4 : Node, T5 : Node, T6 : Node, T7 : Node, T8 : Node, T9 : Node>(
-        node: T9,
+        override val node: T9,
         context: NodeContext
     ) : Choice9Node<T1, T2, T3, T4, T5, T6, T7, T8, T9>(node, context)
 }


### PR DESCRIPTION
Instead of requiring casting to access

```kotlin
MappedParser(ChoiceParser(FooParser(), BarParser())) { node ->
    when (node) {
        is Choice2Node.Option1 -> (node.node as FooNode).foo
        is Choice2Node.Option2 -> (node.node as BarNode).bar
    }
}
```

we can rely on the compiler to check

```kotlin
MappedParser(ChoiceParser(FooParser(), BarParser())) { node ->
    when (node) {
        is Choice2Node.Option1 -> node.node.foo
        is Choice2Node.Option2 -> node.node.bar
    }
}
```