### PR TITLE
Lazily construct message in ParserException

### DIFF
--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/parser/ParserException.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/parser/ParserException.kt
@@ -7,12 +7,13 @@ public class ParserException(
     public val actualMessage: String,
     public val parser: Parser<*>,
     public val input: ParserContext
-) : Exception(
-    """
+) : Exception() {
+    override val message: String
+        get() = """
     |Parse error at ${input.sourcePosition} (${parser::class.simpleName})
     |
     |$actualMessage
     |
     ${input.getSurroundingText(input.sourcePosition).lines().joinToString(separator = "\n") { "|$it" }}
     """.trimMargin()
-)
+}


### PR DESCRIPTION
I've been evaluating kudzu as a replacement for a legacy parser, and so far I am really enjoying it. One surprising thing I found however was when testing on real data (around 18,000 simple expressions), our legacy parser took half a second, while kudzu was taking 5 seconds for the same input!

After looking at a profile, I found that kudzu was spending quite a bit of time in ParserException, simply building a String. The change in this PR brought the time to parse the inputs down to about 900ms.

Here's a comparison of the output of running KudzuPerformanceTests before and after the change (MacOS 13.1, M1 Max):

**main**
```
Total duration of 10000 runs: 668.981360ms
Mean test duration: 66.898us
Test duration spread: [51.25us, 58.708us, 2.381625ms]
standard deviation: 47.77us

Total duration of 10 runs: 16.347295418s
Mean test duration: 1.634729541s
Test duration spread: [1.592183542s, 1.604958417s, 1.707501333s]
standard deviation: 37.976350ms
```

**branch with fix**
```
Total duration of 10000 runs: 436.505520ms
Mean test duration: 43.65us
Test duration spread: [29.333us, 37.375us, 2.556458ms]
standard deviation: 38.442us

Total duration of 10 runs: 16.574471960s
Mean test duration: 1.657447196s
Test duration spread: [1.588313334s, 1.699098500s, 1.782630750s]
standard deviation: 52.073288ms
```

The difference isn't as significant as I saw with my own  much larger data set, so perhaps the tests here don't hit this case as frequently; still, the speed up is reflected in the total duration .