### PR TITLE
Lazily construct text in ValueNode

### DIFF
--- a/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/mapped/ValueNode.kt
+++ b/kudzu-core/src/commonMain/kotlin/com/copperleaf/kudzu/node/mapped/ValueNode.kt
@@ -15,5 +15,6 @@ public class ValueNode<T>(
 ) : TerminalNode(
     context
 ) {
-    override val text: String = value.toString()
+    override val text: String
+        get() = value.toString()
 }


### PR DESCRIPTION
We have been using Kudzu extensively in one of our projects. During profiling we have noticed that some of our `toString()` functions where exceedingly often called within the parser. Upon further investigation, we found out that the `ValueNode.text` field is always populated with `value.toString()`, even if the textual representation of the value is not needed at all. While this is negligible for small types, this can quickly grow out of hand for complex custom values where the toString() prints lists, maps, etc.

To prevent this issue this patch changes the text field to a getter function. This allows for the same behavior if one needs the text output of the value's node, but only computes the value when actually needed. This is a similar fix like #8.